### PR TITLE
Exclusively use user-data when available

### DIFF
--- a/osc_tethys.lua
+++ b/osc_tethys.lua
@@ -2299,7 +2299,12 @@ function togglePictureInPicture()
         end
     end
     tethys.isPictureInPicture = not isPiP
-    utils.shared_script_property_set("pictureinpicture", tostring(tethys.isPictureInPicture))
+
+	if mp.del_property then
+		mp.set_property_native("user-data/pictureinpicture", tostring(tethys.isPictureInPicture))
+    else
+		utils.shared_script_property_set("pictureinpicture", tostring(tethys.isPictureInPicture))
+    end
 end
 
 
@@ -4818,13 +4823,21 @@ function update_margins()
         reset_margins()
     end
 
-    utils.shared_script_property_set("osc-margins",
+	if mp.del_property then
+		mp.set_property_native("user-data/osc/margins", margins)
+    else
+		utils.shared_script_property_set("osc-margins",
         string.format("%f,%f,%f,%f", margins.l, margins.r, margins.t, margins.b))
+	end
 end
 
 function shutdown()
     reset_margins()
-    utils.shared_script_property_set("osc-margins", nil)
+    if mp.del_property then
+		mp.del_property("user-data/osc")
+    else
+		utils.shared_script_property_set("osc-margins", nil)
+    end
 end
 
 --
@@ -5481,7 +5494,12 @@ function visibility_mode(mode, no_osd)
     end
 
     user_opts.visibility = mode
-    utils.shared_script_property_set("osc-visibility", mode)
+	
+	if mp.del_property then
+		mp.set_property_native("user-data/osc/visibility", mode)
+    else
+		utils.shared_script_property_set("osc-visibility", mode)
+	end
 
     if not no_osd and tonumber(mp.get_property("osd-level")) >= 1 then
         mp.osd_message("OSC visibility: " .. mode)
@@ -5513,7 +5531,12 @@ function idlescreen_visibility(mode, no_osd)
         user_opts.idlescreen = false
     end
 
-    utils.shared_script_property_set("osc-idlescreen", mode)
+	
+	if mp.del_property then
+		mp.set_property_native("user-data/osc/idlescreen", user_opts.idlescreen)
+    else
+		utils.shared_script_property_set("osc-idlescreen", mode)
+    end
 
     if not no_osd and tonumber(mp.get_property("osd-level")) >= 1 then
         mp.osd_message("OSC logo visibility: " .. tostring(mode))


### PR DESCRIPTION
shared-script-properties deprecated error fix for tethys UI